### PR TITLE
MAK-4: Link to extranet customer order

### DIFF
--- a/includes/class-wc-meta-box-maksuturva.php
+++ b/includes/class-wc-meta-box-maksuturva.php
@@ -69,7 +69,7 @@ class WC_Meta_Box_Maksuturva {
 		}
 
 		/** @var WC_Gateway_Maksuturva $gateway */
-		$gateway->render( 'meta-box', 'admin', array( 'message' => self::get_messages( $payment ) ) );
+		$gateway->render( 'meta-box', 'admin', array( 'message' => self::get_messages( $payment ), 'extranet_payment_url' => self::get_extranet_payment_url($payment, $gateway), 'payment_id' => $payment->get_payment_id() ) );
 	}
 
 	/**
@@ -110,5 +110,19 @@ class WC_Meta_Box_Maksuturva {
 		}
 
 		return $msg;
+	}
+
+	/**
+	 * Get extranet payment url.
+	 *
+	 * Returns the extranet payment url for the given payment.
+	 *
+	 * @param WC_Payment_Maksuturva $payment The Svea payment object.
+	 * @param WC_Gateway_Maksuturva $gateway The gateway object.
+	 *
+	 * @return string
+	 */
+	private static function get_extranet_payment_url($payment, $gateway) {
+		return $gateway->get_gateway_url() . '/dashboard/PaymentEvent.db?pmt_id=' . $payment->get_payment_id();
 	}
 }

--- a/templates/admin/meta-box.php
+++ b/templates/admin/meta-box.php
@@ -36,6 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 
 <p class="comment-notes">
+	<a href="<?php echo esc_url( $extranet_payment_url ); ?>" target="_blank"><?php echo esc_attr( $payment_id ); ?></a>:
 	<?php echo esc_attr( $message ); ?>
 </p>
 


### PR DESCRIPTION
I added a link to the extranet page to the "Maksuturva order details" box. The payment id there is clickable and points to link with form: [GATEWAY_URL]/dashboard/PaymentEvent.db?pmt_id=[PAYMENT_ID]

![Kuvakaappaus 2020-03-26 13-35-41](https://user-images.githubusercontent.com/56871549/77642702-c2934480-6f66-11ea-85e9-05f7e9ada710.png)
