### PR TITLE
Add missing static keyword for truncate_table()

### DIFF
--- a/includes/class-wc-payment-checker-maksuturva.php
+++ b/includes/class-wc-payment-checker-maksuturva.php
@@ -97,7 +97,7 @@ class WC_Payment_Checker_Maksuturva {
 	 *
 	 * @since 2.0.5
 	 */
-	private function truncate_table() {
+	private static function truncate_table() {
 		global $wpdb;
 		$tbl = $wpdb->prefix . self::TABLE_NAME;
 


### PR DESCRIPTION
`self::truncate_table();` is called in clean install, but `truncate_table()` isn't a static function.

Resulting in error when activating the plugin.
`Fatal error: Uncaught Error: Non-static method WC_Payment_Checker_Maksuturva::truncate_table() cannot be called statically in includes/class-wc-payment-checker-maksuturva.php:77`